### PR TITLE
Fix version of sbt-scalafix

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,3 +1,3 @@
 repo = My Repo
 scalameta_version = maven(org.scalameta, scalameta_2.12)
-scalafix_version = maven(ch.epfl.scala, scalafix-core_2.12)
+scalafix_version = maven(ch.epfl.scala, scalafix-cli_2.12.11)


### PR DESCRIPTION
There seems to be a 2.3.0-RC1 release of scalafix-core_2.12 which is not a valid version for sbt-scalafix plugin.
    

**Workaround**: we choose scalafix-cli version which give us the right version.

Closes #10  