### PR TITLE
Update Scalafix template and add crossBuild config, take 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
-on:
-  push:
+on: [push, pull_request]
 jobs:
   formatting:
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import java.lang.ProcessBuilder
 lazy val root = project
   .in(file("."))
   .settings(
@@ -9,13 +8,14 @@ lazy val root = project
       val _ = (g8Test in Test).toTask("").value
       val process = new ProcessBuilder("sbt", "tests/test")
         .directory(file("target/g8/scalafix"))
-        .run()
+        .start()
       assert(process.exitValue() == 0, "Non-zero exit from sbt tests/test")
     },
-    scriptedLaunchOpts ++= List("-Xms1024m",
-                                "-Xmx1024m",
-                                "-XX:ReservedCodeCacheSize=128m",
-                                "-XX:MaxPermSize=256m",
-                                "-Xss2m",
-                                "-Dfile.encoding=UTF-8")
+    scriptedLaunchOpts ++= List(
+      "-Xms1024m",
+      "-Xmx1024m",
+      "-XX:ReservedCodeCacheSize=128m",
+      "-Xss2m",
+      "-Dfile.encoding=UTF-8"
+    )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,16 @@
-lazy val root = project
-  .in(file("."))
+import scala.sys.process._
+
+lazy val root = (project in file("."))
   .settings(
-    name := "hello-world",
-    resolvers += Resolver.typesafeIvyRepo("releases"),
-    test in Test := {
+    name := "scalafix.g8-root",
+    Test / test := {
+      val _ = (Test / g8Test).toTask("").value
       val s = streams.value
-      val _ = (g8Test in Test).toTask("").value
-      val process = new ProcessBuilder("sbt", "tests/test")
-        .directory(file("target/g8/scalafix"))
-        .start()
-      assert(process.exitValue() == 0, "Non-zero exit from sbt tests/test")
+      s.log.info(
+        "running our own sbt in the copied directory to mimic the scripted test")
+      val p = Process(Seq("sbt", "tests/test"),
+                      (Test / g8 / target).value / "scalafix").run()
+      assert(p.exitValue() == 0, "Non-zero exit from sbt tests/test")
     },
     scriptedLaunchOpts ++= List(
       "-Xms1024m",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.3.13

--- a/project/giter8.test
+++ b/project/giter8.test
@@ -1,1 +1,3 @@
-> tests/test
+# This template creates an sbt build in a subdirectory named "scalafix"
+# so we can't run traditional scripted test that assumes src/main/g8 to contain a build
+> about

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.8.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.0")

--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,11 @@ If the rule is a linter that prohibits vars, the name can be `NoVars`.
 To try out the latest Scalafix milestone in the v0.6.x series,
 follow the instructions from the readme in the [scalafix/](scalafix/readme.md)
 directory.
+
+## Template license
+
+Written in 2020 by Scala Center
+
+To the extent possible under law, the author(s) have dedicated all copyright and related
+and neighboring rights to this template to the public domain worldwide.
+This template is distributed without any warranty. See <https://creativecommons.org/publicdomain/zero/1.0/>.

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,3 +1,3 @@
 repo = My Repo
 scalameta_version = maven(org.scalameta, scalameta_2.12)
-scalafix_version = maven(ch.epfl.scala, scalafix-cli_2.12.11)
+scalafix_version = maven(ch.epfl.scala, scalafix-cli_2.12.12)

--- a/src/main/g8/scalafix/build.sbt
+++ b/src/main/g8/scalafix/build.sbt
@@ -1,6 +1,8 @@
 lazy val V = _root_.scalafix.sbt.BuildInfo
 inThisBuild(
   List(
+    scalaVersion := V.scala212,
+    crossScalaVersions := List(V.scala213, V.scala212, V.scala211),
     organization := "com.example",
     homepage := Some(url("https://github.com/com/example")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
@@ -12,7 +14,6 @@ inThisBuild(
         url("https://example.com")
       )
     ),
-    scalaVersion := V.scala212,
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions ++= List(
       "-Yrangepos",

--- a/src/main/g8/scalafix/project/build.properties
+++ b/src/main/g8/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.3.13

--- a/src/main/g8/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/src/main/g8/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,7 +1,8 @@
 package fix
 
-import scalafix.testkit.SemanticRuleSuite
+import scalafix.testkit._
+import org.scalatest.FunSuiteLike
 
-class RuleSuite extends SemanticRuleSuite() {
+class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
   runAllTests()
 }


### PR DESCRIPTION
This is a minor fix on top of https://github.com/scalacenter/scalafix.g8/pull/13

### note

scalafix.g8 is a weird template since it creates an sbt build inside `scalafix` subdirectory as opposed to the root of the repo. Because of that, the normal scripted test doesn't work well, and instead `build.sbt` launches its own sbt to run the test manually. This fixes some details and adds comment documenting the fact.