### PR TITLE
Fix the setting for the tests project

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -25,9 +25,9 @@ lazy val tests = project
   .settings(
     libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafix % Test cross CrossVersion.full,
     scalafixTestkitOutputSourceDirectories :=
-      sourceDirectories.in(output, Compile).value,
+      unmanagedSourceDirectories.in(output, Compile).value,
     scalafixTestkitInputSourceDirectories :=
-      sourceDirectories.in(input, Compile).value,
+      unmanagedSourceDirectories.in(input, Compile).value,
     scalafixTestkitInputClasspath :=
       fullClasspath.in(input, Compile).value,
     compile.in(Compile) := compile

--- a/scalafix/readme.md
+++ b/scalafix/readme.md
@@ -61,9 +61,9 @@ index 830ec17d..5f73b8e3 100644
 -    )
 +    
 +    scalafixTestkitOutputSourceDirectories :=
-+      sourceDirectories.in(output, Compile).value,
++      unmanagedSourceDirectories.in(output, Compile).value,
 +    scalafixTestkitInputSourceDirectories :=
-+      sourceDirectories.in(input, Compile).value,
++      unmanagedSourceDirectories.in(input, Compile).value,
 +    scalafixTestkitInputClasspath :=
 +      fullClasspath.in(input, Compile).value
    )

--- a/scalafix/rules/src/main/scala/fix/Scalafixg8_v0_6.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalafixg8_v0_6.scala
@@ -112,9 +112,9 @@ class Scalafixg8_v0_6 extends SyntacticRule("Scalafixg8_v0_6") {
         patch += Patch.replaceTree(
           t,
           """scalafixTestkitOutputSourceDirectories :=
-            |      sourceDirectories.in(output, Compile).value,
+            |      unmanagedSourceDirectories.in(output, Compile).value,
             |    scalafixTestkitInputSourceDirectories :=
-            |      sourceDirectories.in(input, Compile).value,
+            |      unmanagedSourceDirectories.in(input, Compile).value,
             |    scalafixTestkitInputClasspath :=
             |      fullClasspath.in(input, Compile).value""".stripMargin
         )

--- a/src/main/g8/scalafix/build.sbt
+++ b/src/main/g8/scalafix/build.sbt
@@ -44,9 +44,9 @@ lazy val tests = project
     compile.in(Compile) := 
       compile.in(Compile).dependsOn(compile.in(input, Compile)).value,
     scalafixTestkitOutputSourceDirectories :=
-      sourceDirectories.in(output, Compile).value,
+      unmanagedSourceDirectories.in(output, Compile).value,
     scalafixTestkitInputSourceDirectories :=
-      sourceDirectories.in(input, Compile).value,
+      unmanagedSourceDirectories.in(input, Compile).value,
     scalafixTestkitInputClasspath :=
       fullClasspath.in(input, Compile).value,
   )


### PR DESCRIPTION
SourceDirectories takes also into account managed directories that contain generated files. Those files do not need to be fixed by scalafix