### PR TITLE
Add an example case for the migration rule

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,4 +3,5 @@ assumeStandardLibraryStripMargin = true
 project.excludeFilters = [
   "main/g8"
   "output/src"
+  "migration-rules/*"
 ]

--- a/migration-rules/v0.9.28/input/src/main/scala/fix/Case2.scala
+++ b/migration-rules/v0.9.28/input/src/main/scala/fix/Case2.scala
@@ -1,0 +1,17 @@
+/*
+rule = v0_9_28
+ */
+package fix
+
+import scala.reflect.ensureAccessible
+import org.scalatest.ConfigMap
+import scalafix.testkit.SemanticRuleSuite
+
+trait BeforeAndAfterAllConfigMapAlt {
+  final def beforeAllAlt: Unit = ()
+}
+class RuleSuite extends SemanticRuleSuite with BeforeAndAfterAllConfigMapAlt {
+  val isSaveExpectField = ensureAccessible(classOf[SemanticRuleSuite].getDeclaredField("isSaveExpect"))
+
+  runAllTests()
+}

--- a/migration-rules/v0.9.28/output/src/main/scala/fix/Case2.scala
+++ b/migration-rules/v0.9.28/output/src/main/scala/fix/Case2.scala
@@ -1,0 +1,15 @@
+package fix
+
+import scala.reflect.ensureAccessible
+import org.scalatest.ConfigMap
+import org.scalatest.FunSuiteLike
+import scalafix.testkit.AbstractSemanticRuleSuite
+
+trait BeforeAndAfterAllConfigMapAlt {
+  final def beforeAllAlt: Unit = ()
+}
+class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike with BeforeAndAfterAllConfigMapAlt {
+  val isSaveExpectField = ensureAccessible(classOf[AbstractSemanticRuleSuite].getDeclaredField("isSaveExpect"))
+
+  runAllTests()
+}

--- a/migration-rules/v0.9.28/rules/src/main/scala/fix/v0_9_28.scala
+++ b/migration-rules/v0.9.28/rules/src/main/scala/fix/v0_9_28.scala
@@ -15,6 +15,13 @@ class v0_9_28 extends SemanticRule("v0_9_28") {
       case t @ init"SemanticRuleSuite(..$_)" =>
         Patch.addGlobalImport(importer"org.scalatest.FunSuiteLike") +
           Patch.replaceTree(t, "AbstractSemanticRuleSuite with FunSuiteLike")
+
+      case t @ init"SemanticRuleSuite" =>
+        Patch.addGlobalImport(importer"org.scalatest.FunSuiteLike") +
+          Patch.replaceTree(t, "AbstractSemanticRuleSuite with FunSuiteLike")
+
+      case t @ q"classOf[..$tpesnel]" => println(s"name = ${tpesnel}")
+        Patch.replaceTree(t, "classOf[AbstractSemanticRuleSuite]")
     }.asPatch
   }
 }


### PR DESCRIPTION
Not working. I don't know how to extract cases like the following without breaking other things 
```
=======
=> Diff
=======
--- obtained
+++ expected
@@ -11,3 +11,3 @@
 class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike with BeforeAndAfterAllConfigMapAlt {
-  val isSaveExpectField = ensureAccessible(classOf[SemanticRuleSuite].getDeclaredField("isSaveExpect"))
+  val isSaveExpectField = ensureAccessible(classOf[AbstractSemanticRuleSuite].getDeclaredField("isSaveExpect"))
```
