### PR TITLE
Revert "hardcode latest version for default as search.maven.org is stale"

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,2 +1,2 @@
 repo = scalafix-my-rules
-scalafix_version = 0.9.28
+scalafix_version = maven(ch.epfl.scala, sbt-scalafix)


### PR DESCRIPTION
This reverts commit ee98b06db0f3726a550c90cf15152eccc3017ceb.

https://github.com/scalacenter/scalafix.g8/pull/19#issuecomment-845650850