### PR TITLE
ScalafixTestkitPlugin now brings scalafix-testkit

### DIFF
--- a/src/main/g8/scalafix/build.sbt
+++ b/src/main/g8/scalafix/build.sbt
@@ -65,7 +65,6 @@ lazy val testsAggregate = Project("tests", file("target/testsAggregate"))
 lazy val tests = projectMatrix
   .settings(
     publish / skip := true,
-    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
     scalafixTestkitOutputSourceDirectories :=
       TargetAxis
         .resolve(output, Compile / unmanagedSourceDirectories)


### PR DESCRIPTION
Blocked by a bump of sbt-scalafix that contains https://github.com/scalacenter/sbt-scalafix/pull/281